### PR TITLE
feat(guac-http): GuacHttpClient libcurl + web_renderer config (Phase 14-A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y -q cmake g++ libssl-dev zlib1g-dev openssh-server
+          sudo apt-get install -y -q cmake g++ libssl-dev zlib1g-dev libcurl4-openssl-dev openssh-server
 
       - name: Configure SSH test server
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,15 @@ VPN/원격접속 기술을 학습하고 직접 구현하는 프로젝트.
 1. **리버스 터널** — 클라이언트가 NAT 뒤에 있어도 서버에서 연결 가능하게
 2. **Zero Trust 인증** — 네트워크 신뢰 없이 매 요청마다 인증 (mTLS/JWT)
 3. **Guacamole 프로토콜** — 서버에서 직접 렌더링해서 브라우저로 전달 (RDP/VNC/SSH 웹화)
-4. **Remote Browser Isolation** — Guacamole 커스텀 프로토콜로 HTTPS 웹 원격 접근 구현. `GuacWebClient`가 Chromium headless를 CDP로 제어해 스크린샷을 캡처하고, 기존 Guacamole blob 스트리밍으로 브라우저 canvas에 전달
+4. **HTTP 웹 프록시** — Guacamole 커스텀 `web` 프로토콜로 HTTP/HTTPS 페이지를 게이트웨이에서 가져와 브라우저에 전달. 기본은 `GuacHttpClient`(libcurl 직접 요청), 선택적으로 `GuacWebClient`(Chromium headless CDP) 전환 가능
 
-최종 결과물: Cloudflare Tunnel + Apache Guacamole + Remote Browser Isolation을 C++로 직접 만든 것
+최종 결과물: Cloudflare Tunnel + Apache Guacamole + HTTP 웹 프록시를 C++로 직접 만든 것
 
 ---
 
 ## 현재 개발 단계
 
-**Phase 13 다음** — Remote Browser Isolation
+**Phase 14 진행 중** — HTTP 웹 프록시 (GuacHttpClient)
 
 - [x] Phase 1 — 기본 TCP 프록시 (멀티스레드) **완료**
 - [x] Phase 2 — epoll 비동기 I/O **완료**
@@ -30,8 +30,9 @@ VPN/원격접속 기술을 학습하고 직접 구현하는 프로젝트.
 - [ ] ~~Phase 9 — 컨트롤 플레인~~ **보류** (SaaS 구조 전제, 현재 목표와 맞지 않음)
 - [ ] ~~Phase 10 — REST API~~ **보류** (동일 이유)
 - [x] Phase 11 — 재연결 및 안정성 **완료**
-- [ ] Phase 12 — 배포 **보류** (Phase 13 완료 후 진행)
-- [ ] Phase 13 — Remote Browser Isolation (GuacWebClient + Chromium CDP) **다음**
+- [ ] Phase 12 — 배포 **보류** (Phase 14 완료 후 진행)
+- [x] Phase 13 — Remote Browser Isolation (GuacWebClient + Chromium CDP) **완료**
+- [ ] Phase 14 — HTTP 웹 프록시 (GuacHttpClient + 터널 라우팅 통합) **다음**
 
 ---
 
@@ -156,23 +157,48 @@ PR을 올린 뒤 다음 Phase 작업을 이어서 시작하지 않는다.
 | 12-B | `build/systemd` | systemd 서비스 파일 (자동 시작 / 재시작 정책) | 리눅스 서버에서 프로세스를 데몬으로 관리. 서버 재부팅 후 자동 복구 |
 | 12-C | `build/compose` | docker-compose (서버 + 게이트웨이 + 설정 볼륨) | 서버/게이트웨이를 한 번에 올리는 로컬 개발 및 배포 환경 구성 |
 
-### Phase 13 — Remote Browser Isolation (GuacWebClient + Chromium CDP)
+### Phase 13 — Remote Browser Isolation (GuacWebClient + Chromium CDP) **완료**
 
-Guacamole는 RDP/VNC/SSH만 지원한다. HTTPS 웹페이지 원격 접근을 위해 `GuacWebClient`를 새 Guacamole 커스텀 프로토콜로 추가한다.
+Guacamole 커스텀 `web` 프로토콜로 Chromium headless CDP를 제어해 스크린샷을 캡처하고 blob 스트리밍으로 브라우저 canvas에 전달.
+Chromium은 cmake configure 시 `scripts/setup_chromium.sh`가 자동으로 탐지/설치한다.
 
-구조: `connect,web,https://...;` → `GuacWebClient` → Chromium headless(CDP) → 스크린샷 → blob 스트리밍 → 브라우저 canvas
+| 세션 | 브랜치 | 작업 |
+|------|--------|------|
+| 13-A | `feat/guac-web-cdp` | Chrome fork/exec + CDP WebSocket + 페이지 로드 |
+| 13-B | `feat/guac-web-stream` | captureScreenshot → JPEG blob 스트리밍 + 라우팅 |
+| 13-C | `feat/guac-web-input` | 마우스/키보드 → CDP Input 이벤트 주입 |
+| 13-D | `feat/guac-web-delta` | 전 프레임 비교 delta 압축 전송 |
+| 13-E | `test/guac-web-e2e` | E2E 테스트 |
 
-`GuacWebClient`는 `GuacVncClient`와 동일한 구조다. 픽셀 소스만 libvncclient 대신 CDP `Page.captureScreenshot`으로 교체된다.
+### Phase 14 — HTTP 웹 프록시 (GuacHttpClient + 터널 라우팅 통합)
 
-Chromium은 cmake configure 시 `scripts/setup_chromium.sh`가 자동으로 탐지/설치한다. apt 불필요.
+Phase 13의 Chromium 방식은 프로세스 오버헤드가 크고 터널 라우팅이 빠져있다.
+Phase 14는 두 가지 문제를 해결한다:
+
+1. **GuacHttpClient** — libcurl 기반 HTTP GET. `response,<status>,<content-type>,<base64-body>;` Guacamole instruction으로 반환. 기본 `web` 구현.
+2. **터널 라우팅 통합** — GuacWebSocketGateway가 TunnelServer를 참조해, NAT 뒤 에이전트를 거쳐 내부 웹 서비스에 도달할 수 있도록 연결.
+3. **web_renderer 설정** — config.json의 `"web_renderer": "http"` (기본) 또는 `"chromium"` 으로 구현체 선택.
+
+Guacamole `web` 프로토콜 흐름:
+```
+브라우저 → connect,web,https://내부서버/path;
+         → GuacWebSocketGateway
+              ├─ web_renderer=http   → GuacHttpClient → (터널 or 직접) → HTTP GET
+              └─ web_renderer=chromium → GuacWebClient → Chromium CDP
+         → response,200,text/html,<base64>;
+브라우저 → iframe src=data:... 렌더링
+```
+
+새 Guacamole instruction:
+```
+response,<status_code>,<content-type>,<base64-encoded-body>;
+```
 
 | 세션 | 브랜치 | 작업 | 왜 필요한가 |
 |------|--------|------|-------------|
-| 13-A | `feat/guac-web-cdp` | Chrome 프로세스 fork/exec + CDP WebSocket 클라이언트 + 페이지 로드 | Chromium을 headless로 구동하고 CDP로 제어하는 기반. `--remote-debugging-port`로 CDP 포트 열기 |
-| 13-B | `feat/guac-web-stream` | `Page.captureScreenshot` 루프 → JPEG blob 스트리밍 + `GuacWebSocketGateway` 라우팅 추가 | 스크린샷을 기존 Guacamole blob 경로로 전송. 프론트엔드 canvas 렌더링은 RDP/VNC와 동일 |
-| 13-C | `feat/guac-web-input` | 마우스/키보드 입력 → CDP `Input.dispatchMouseEvent` / `Input.dispatchKeyEvent` | 사용자 입력을 Chromium에 주입해 양방향 제어 완성 |
-| 13-D | `feat/guac-web-delta` | 변경 영역 delta 압축 (전 프레임 비교 → 변경된 rect만 전송) | 전체 프레임 전송은 대역폭 낭비. delta로 실시간성 확보 |
-| 13-E | `test/guac-web-e2e` | 프론트엔드 ↔ GuacWebClient ↔ Chromium E2E 테스트 | 전 구간 검증 |
+| 14-A | `feat/guac-http` | GuacHttpClient (libcurl) + `response` instruction + config `web_renderer` + GuacWebSocketGateway 라우팅 | HTTP 직접 구현. Chromium 없이 웹 페이지 접근 가능. libcurl은 시스템 의존성(find_package) |
+| 14-B | `feat/guac-tunnel-route` | GuacWebSocketGateway ↔ TunnelServer 연결 — agent_id 기반 터널 경유 HTTP | Guacamole와 리버스 터널이 분리되어 있어 NAT 뒤 웹 서비스에 접근 불가. 이 작업으로 연결 |
+| 14-C | `feat/guac-http-frontend` | 프론트엔드 `response` instruction 처리 — iframe 또는 새 탭 렌더링 | 브라우저가 base64 HTML을 받아 표시하는 UI 완성 |
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ find_package(OpenSSL REQUIRED)
 # ZLIB 찾기 (Phase 8-B: PNG 인코딩에 사용)
 find_package(ZLIB REQUIRED)
 
+# libcurl 찾기 (Phase 14-A: GuacHttpClient HTTP GET)
+find_package(CURL REQUIRED)
+
 # 외부 라이브러리 (FetchContent)
 include(FetchContent)
 
@@ -161,6 +164,7 @@ set(SOURCES
     src/guac_ssh.cpp
     src/guac_vnc.cpp
     src/guac_web.cpp
+    src/guac_http.cpp
     src/guac_websocket.cpp
     src/utils/config.cpp
     src/utils/logger.cpp
@@ -192,6 +196,7 @@ target_link_libraries(proxy
     ZLIB::ZLIB       # PNG 인코딩 (Phase 8-B/D)
     OpenSSL::SSL
     OpenSSL::Crypto
+    CURL::libcurl    # HTTP GET (Phase 14-A)
     pthread
     nlohmann_json::nlohmann_json
 )

--- a/README.md
+++ b/README.md
@@ -72,18 +72,36 @@ Guacamole 프로토콜은 길이 접두사 텍스트 포맷이다:
 4.draw,1.0,2.10,3.100,3.200;   ← opcode.length.arg, ...
 ```
 
-### webkit headless 스트리밍 (HTTPS)
+### HTTP 웹 프록시 (web 프로토콜)
 
-Guacamole는 HTTPS 웹페이지를 지원하지 않는다.
-이를 위해 게이트웨이 서버에서 headless 브라우저(webkit/Chromium)가 페이지를 렌더링하고,
-변경된 영역(delta)만 압축해 WebSocket으로 브라우저에 스트리밍한다.
-사용자 입력은 역방향으로 headless 브라우저에 주입된다.
+Guacamole는 HTTP/HTTPS 웹페이지를 기본 지원하지 않는다.
+`web` 커스텀 프로토콜로 이를 확장한다.
+
+브라우저가 `connect,web,https://내부서버/path;`를 보내면
+게이트웨이가 해당 URL을 서버 측에서 직접 요청하고 결과를 `response` instruction으로 반환한다.
 
 ```
-브라우저 ←─ WSS (delta frame) ─→ 게이트웨이
-              ─ input event ─→    headless webkit
-                                      ↕ HTTPS
-                                  내부 웹 서비스
+브라우저
+  connect,web,https://내부서버/path;
+        ↓
+  GuacWebSocketGateway
+        ├─ web_renderer=http (기본)
+        │      → GuacHttpClient(libcurl) → HTTP GET
+        │      → response,200,text/html,<base64>;
+        └─ web_renderer=chromium (선택)
+               → GuacWebClient → Chromium headless CDP
+               → delta frame 스트리밍
+```
+
+새 Guacamole instruction:
+```
+response,200,text/html,<base64-encoded-body>;
+```
+
+`config.json`의 `web_renderer` 필드로 구현체를 선택한다:
+```json
+{ "web_renderer": "http" }      // 기본 — libcurl 직접 요청, 경량
+{ "web_renderer": "chromium" }  // JS 실행이 필요한 SPA 등
 ```
 
 ---
@@ -181,7 +199,7 @@ make -j$(nproc)
 │   ├─ ssh ──────────────────────▶ SSH 서버   │
 │   ├─ rdp ──────────────────────▶ RDP 서버   │
 │   ├─ vnc ──────────────────────▶ VNC 서버   │
-│   └─ web ──▶ Chromium headless ─▶ URL       │
+│   └─ web ──▶ GuacHttpClient ────▶ URL       │
 └─────────────────────────────────────────────┘
 ```
 
@@ -232,9 +250,10 @@ make -j$(nproc)
 ```json
 // config.json
 {
-  "agent_port": 9900,
-  "proxy_port": 9901,
-  "guac_port":  8765
+  "agent_port":   9900,
+  "proxy_port":   9901,
+  "guac_port":    8765,
+  "web_renderer": "http"   // "http"(기본) 또는 "chromium"
 }
 ```
 
@@ -302,8 +321,10 @@ cd build && ctest --output-on-failure
 | CMake | 3.14+ | 시스템 |
 | GCC | 11+ (C++17) | 시스템 |
 | OpenSSL | 3.x | 시스템 (find_package) |
+| libcurl | 7.x+ | 시스템 (find_package) |
 | nlohmann/json | v3.11.3 | FetchContent |
 | Google Test | v1.14.0 | FetchContent |
+| Chromium | 최신 stable | 선택 — `web_renderer=chromium` 사용 시 자동 탐지/설치 |
 
 ---
 
@@ -322,7 +343,8 @@ tunnel-proxy/
 │   │   ├── tunnel_server.h     # 에이전트 수신 + 세션 라우터
 │   │   ├── mtls_context.h      # mTLS SSL_CTX + CN 추출
 │   │   ├── jwt_verifier.h      # HS256/RS256 JWT 검증
-│   │   └── access_policy.h     # 접근 제어 정책 (first-match)
+│   │   ├── access_policy.h     # 접근 제어 정책 (first-match)
+│   │   └── guac_http.h         # libcurl HTTP 클라이언트 (web 프로토콜 기본 구현)
 │   └── utils/
 │       ├── config.h
 │       └── logger.h

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
-  "agent_port": 9900,
-  "proxy_port": 9901,
-  "guac_port":  8765,
-  "verbose":    true,
-  "log_file":   "proxy.log"
+  "agent_port":   9900,
+  "proxy_port":   9901,
+  "guac_port":    8765,
+  "web_renderer": "http",
+  "verbose":      true,
+  "log_file":     "proxy.log"
 }

--- a/include/core/guac_http.h
+++ b/include/core/guac_http.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "core/guac_parser.h"
+#include <string>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <atomic>
+
+namespace proxy {
+
+/**
+ * @file guac_http.h
+ * @brief Phase 14-A — libcurl 기반 HTTP 클라이언트 (web 프로토콜 기본 구현)
+ *
+ * ── 역할 ──────────────────────────────────────────────────────────────────
+ *
+ *   Guacamole `web` 프로토콜의 기본 구현체.
+ *   지정한 URL을 libcurl로 HTTP GET하고 응답을 `response` instruction으로 반환한다.
+ *
+ *   GuacWebClient(Chromium CDP)와 동일한 InstructionCallback 인터페이스를 공유하므로
+ *   GuacWebSocketGateway에서 web_renderer 설정에 따라 투명하게 교체 가능하다.
+ *
+ * ── Guacamole response instruction ───────────────────────────────────────
+ *
+ *   connect,web,https://내부서버/path;  ← 브라우저 → 게이트웨이
+ *   response,200,text/html,<base64>;   ← 게이트웨이 → 브라우저
+ *
+ *   형식: response,<status_code>,<content_type>,<base64_encoded_body>;
+ *
+ * ── GuacWebClient와의 구조적 유사성 ──────────────────────────────────────
+ *
+ *   - connect() → 백그라운드 스레드(worker_)에서 HTTP 요청 실행
+ *   - InstructionCallback → response instruction 전달
+ *   - disconnect() → 진행 중인 요청 중단 + worker_ 조인
+ *
+ *   HTTP는 일회성(one-shot) 요청이므로 send_mouse / send_key는 지원하지 않는다.
+ *
+ * ── 스레드 모델 ───────────────────────────────────────────────────────────
+ *
+ *   connect()는 백그라운드 스레드(worker_)를 시작하고 즉시 반환한다.
+ *   worker_는 curl_easy_perform()으로 응답 수집 후 callback_을 호출하고 종료한다.
+ *   disconnect()는 abort_ 플래그를 설정하고 worker_ 종료를 대기한다.
+ */
+class GuacHttpClient {
+public:
+    /**
+     * InstructionCallback — response instruction이 준비되면 호출된다.
+     * 콜백은 worker_ 스레드에서 호출된다.
+     */
+    using InstructionCallback = std::function<void(const GuacInstruction&)>;
+
+    explicit GuacHttpClient(InstructionCallback callback);
+    ~GuacHttpClient();
+
+    GuacHttpClient(const GuacHttpClient&)            = delete;
+    GuacHttpClient& operator=(const GuacHttpClient&) = delete;
+
+    /**
+     * 지정한 URL을 HTTP GET으로 요청한다.
+     *
+     * 비동기 — worker_ 스레드에서 요청을 처리한다.
+     * 요청 완료 시 response instruction을 콜백으로 전달하고 is_connected()가 false로 전환된다.
+     *
+     * @param url  요청할 URL (예: "https://example.com")
+     */
+    void connect(const std::string& url);
+
+    /**
+     * 진행 중인 요청을 중단하고 worker_ 스레드 종료를 대기한다.
+     * 이미 완료되거나 연결되지 않은 상태에서 호출해도 안전하다.
+     */
+    void disconnect();
+
+    /** @return worker_ 스레드가 실행 중이면 true */
+    bool is_connected() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+
+    InstructionCallback callback_;
+    std::atomic<bool>   connected_{false};
+    std::atomic<bool>   abort_{false};
+    std::thread         worker_;
+
+    /**
+     * run_request — worker_ 스레드 진입점
+     *
+     * 실행 순서:
+     *   1. curl_easy_init()으로 CURL 핸들 초기화
+     *   2. curl_easy_perform()으로 HTTP GET 수행 (응답 바디를 메모리로 수집)
+     *   3. HTTP 상태 코드와 Content-Type 헤더 추출
+     *   4. 응답 바디를 base64 인코딩
+     *   5. response instruction 생성 및 콜백 호출
+     *   6. connected_ = false로 전환
+     *
+     * @param url  요청할 URL
+     */
+    void run_request(const std::string& url);
+};
+
+} // namespace proxy

--- a/include/core/guac_websocket.h
+++ b/include/core/guac_websocket.h
@@ -5,6 +5,7 @@
 #include "core/guac_ssh.h"
 #include "core/guac_vnc.h"
 #include "core/guac_web.h"
+#include "core/guac_http.h"
 
 #include <memory>
 #include <thread>
@@ -52,6 +53,12 @@ public:
     GuacWebSocketGateway& operator=(const GuacWebSocketGateway&) = delete;
 
     /**
+     * web 프로토콜 렌더러를 설정한다. start() 이전에 호출해야 한다.
+     * @param renderer  "http" (기본, libcurl) 또는 "chromium" (Chromium CDP 스트리밍)
+     */
+    void set_web_renderer(const std::string& renderer);
+
+    /**
      * 지정한 포트에서 WebSocket 연결 수신을 시작한다.
      * @throws std::runtime_error bind/listen 실패 시
      */
@@ -73,6 +80,7 @@ private:
     std::atomic<bool>     running_{false};
     int                   listen_fd_{-1};
     std::thread           accept_thread_;
+    std::string           web_renderer_{"http"};
 
     void accept_loop();
     void handle_connection(int fd);

--- a/include/utils/config.h
+++ b/include/utils/config.h
@@ -49,8 +49,10 @@ public:
     std::string get_agent_id()    const { return agent_id_; }
 
     // ── 공통 ──────────────────────────────────────────────────────────────────
-    bool        is_verbose()     const { return verbose_; }
-    std::string get_log_file()   const { return log_file_; }
+    bool        is_verbose()       const { return verbose_; }
+    std::string get_log_file()     const { return log_file_; }
+    /** web 프로토콜 렌더러: "http" (기본, libcurl) 또는 "chromium" (CDP 스트리밍) */
+    std::string get_web_renderer() const { return web_renderer_; }
 
 private:
     Config() = default;
@@ -66,6 +68,7 @@ private:
     std::string agent_id_    = "agent-1";
 
     // 공통
-    bool        verbose_  = false;
-    std::string log_file_ = "";
+    bool        verbose_      = false;
+    std::string log_file_     = "";
+    std::string web_renderer_ = "http";
 };

--- a/src/guac_http.cpp
+++ b/src/guac_http.cpp
@@ -1,0 +1,168 @@
+/**
+ * @file guac_http.cpp
+ * @brief Phase 14-A — libcurl HTTP GET + response Guacamole instruction
+ *
+ * ── libcurl 응답 수집 ─────────────────────────────────────────────────────
+ *
+ *   CURLOPT_WRITEFUNCTION + CURLOPT_WRITEDATA로 응답 바디를 std::string에 누적한다.
+ *   CURLOPT_HEADERFUNCTION으로 Content-Type 헤더를 추출한다.
+ *
+ * ── base64 인코딩 ─────────────────────────────────────────────────────────
+ *
+ *   OpenSSL EVP_EncodeBlock을 사용한다 (이미 링크된 의존성이므로 추가 라이브러리 불필요).
+ *
+ * ── response instruction ──────────────────────────────────────────────────
+ *
+ *   형식: response,<status_code>,<content_type>,<base64_body>;
+ *   GuacParser::serialize()로 직렬화해 콜백에 전달한다.
+ */
+
+#include "core/guac_http.h"
+
+#include <curl/curl.h>
+#include <openssl/evp.h>    // EVP_EncodeBlock
+
+#include <stdexcept>
+#include <cstring>
+
+namespace proxy {
+
+// ── Impl ──────────────────────────────────────────────────────────────────
+
+struct GuacHttpClient::Impl {
+    // 응답 수집 버퍼
+    std::string body;
+    std::string content_type;
+    long        status_code{0};
+};
+
+// ── libcurl 콜백 ──────────────────────────────────────────────────────────
+
+static size_t write_body(void* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* buf = static_cast<std::string*>(userdata);
+    buf->append(static_cast<char*>(ptr), size * nmemb);
+    return size * nmemb;
+}
+
+static size_t write_header(void* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* ct = static_cast<std::string*>(userdata);
+    std::string line(static_cast<char*>(ptr), size * nmemb);
+    // "Content-Type: text/html; charset=utf-8\r\n"
+    const std::string prefix = "content-type:";
+    std::string lower = line;
+    for (auto& c : lower) c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+    if (lower.find(prefix) == 0) {
+        size_t start = prefix.size();
+        while (start < line.size() && (line[start] == ' ' || line[start] == '\t')) start++;
+        size_t end = line.find_first_of("\r\n", start);
+        *ct = line.substr(start, end == std::string::npos ? std::string::npos : end - start);
+    }
+    return size * nmemb;
+}
+
+// ── base64 인코딩 ─────────────────────────────────────────────────────────
+
+static std::string base64_encode(const std::string& data) {
+    if (data.empty()) return "";
+    size_t out_len = 4 * ((data.size() + 2) / 3) + 1;
+    std::string result(out_len, '\0');
+    int written = EVP_EncodeBlock(
+        reinterpret_cast<unsigned char*>(result.data()),
+        reinterpret_cast<const unsigned char*>(data.data()),
+        static_cast<int>(data.size())
+    );
+    result.resize(static_cast<size_t>(written));
+    return result;
+}
+
+// ── GuacHttpClient 구현 ───────────────────────────────────────────────────
+
+GuacHttpClient::GuacHttpClient(InstructionCallback callback)
+    : impl_(std::make_unique<Impl>())
+    , callback_(std::move(callback))
+{}
+
+GuacHttpClient::~GuacHttpClient() {
+    disconnect();
+}
+
+bool GuacHttpClient::is_connected() const {
+    return connected_.load();
+}
+
+void GuacHttpClient::connect(const std::string& url) {
+    if (connected_.load()) return;
+    abort_     = false;
+    connected_ = true;
+    worker_    = std::thread(&GuacHttpClient::run_request, this, url);
+}
+
+void GuacHttpClient::disconnect() {
+    abort_ = true;
+    if (worker_.joinable()) worker_.join();
+    connected_ = false;
+}
+
+void GuacHttpClient::run_request(const std::string& url) {
+    impl_->body.clear();
+    impl_->content_type.clear();
+    impl_->status_code = 0;
+
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        // 초기화 실패 → error instruction
+        GuacInstruction err;
+        err.opcode = "error";
+        err.args   = {"curl_easy_init failed", "500"};
+        if (callback_) callback_(err);
+        connected_ = false;
+        return;
+    }
+
+    curl_easy_setopt(curl, CURLOPT_URL,            url.c_str());
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS,      5L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT,        30L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+    // SSL 검증 — 자체 서명 인증서를 허용하려면 CURLOPT_SSL_VERIFYPEER를 0으로 설정
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    // 응답 바디 수집
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_body);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA,     &impl_->body);
+    // Content-Type 헤더 수집
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, write_header);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA,     &impl_->content_type);
+
+    CURLcode res = curl_easy_perform(curl);
+
+    if (!abort_.load()) {
+        if (res == CURLE_OK) {
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &impl_->status_code);
+
+            std::string ct = impl_->content_type.empty() ? "application/octet-stream"
+                                                          : impl_->content_type;
+            std::string b64 = base64_encode(impl_->body);
+
+            GuacInstruction instr;
+            instr.opcode = "response";
+            instr.args   = {
+                std::to_string(impl_->status_code),
+                ct,
+                b64
+            };
+            if (callback_) callback_(instr);
+        } else {
+            // HTTP 요청 실패 → error instruction
+            GuacInstruction err;
+            err.opcode = "error";
+            err.args   = {curl_easy_strerror(res), "502"};
+            if (callback_) callback_(err);
+        }
+    }
+
+    curl_easy_cleanup(curl);
+    connected_ = false;
+}
+
+} // namespace proxy

--- a/src/guac_websocket.cpp
+++ b/src/guac_websocket.cpp
@@ -54,10 +54,11 @@ struct WsSession {
     std::atomic<bool> active{true};
     std::mutex        send_mutex;
 
-    std::unique_ptr<GuacRdpClient> rdp;
-    std::unique_ptr<GuacSshClient> ssh;
-    std::unique_ptr<GuacVncClient> vnc;
-    std::unique_ptr<GuacWebClient> web;
+    std::unique_ptr<GuacRdpClient>  rdp;
+    std::unique_ptr<GuacSshClient>  ssh;
+    std::unique_ptr<GuacVncClient>  vnc;
+    std::unique_ptr<GuacWebClient>  web;
+    std::unique_ptr<GuacHttpClient> http;
 
     explicit WsSession(int f) : fd(f) {}
 };
@@ -191,6 +192,10 @@ GuacWebSocketGateway::GuacWebSocketGateway()
     : impl_(std::make_unique<Impl>())
 {}
 
+void GuacWebSocketGateway::set_web_renderer(const std::string& renderer) {
+    web_renderer_ = renderer;
+}
+
 GuacWebSocketGateway::~GuacWebSocketGateway() {
     stop();
 }
@@ -306,10 +311,17 @@ void GuacWebSocketGateway::handle_connection(int fd) {
     } else if (protocol == "web") {
         // connect,web,<url>[,<width>[,<height>]];
         // 예: connect,web,https://example.com,1280,800;
-        int w = std::stoi(get(2, "1280"));
-        int h = std::stoi(get(3, "800"));
-        session->web = std::make_unique<GuacWebClient>(cb);
-        session->web->connect(get(1, "about:blank"), w, h);
+        const std::string url = get(1, "about:blank");
+        if (web_renderer_ == "chromium") {
+            int w = std::stoi(get(2, "1280"));
+            int h = std::stoi(get(3, "800"));
+            session->web = std::make_unique<GuacWebClient>(cb);
+            session->web->connect(url, w, h);
+        } else {
+            // "http" (기본) — libcurl 직접 요청
+            session->http = std::make_unique<GuacHttpClient>(cb);
+            session->http->connect(url);
+        }
     } else {
         GuacInstruction err;
         err.opcode = "error";
@@ -356,10 +368,11 @@ void GuacWebSocketGateway::handle_connection(int fd) {
     }
 
     session->active = false;
-    if (session->rdp) session->rdp->disconnect();
-    if (session->ssh) session->ssh->disconnect();
-    if (session->vnc) session->vnc->disconnect();
-    if (session->web) session->web->disconnect();
+    if (session->rdp)  session->rdp->disconnect();
+    if (session->ssh)  session->ssh->disconnect();
+    if (session->vnc)  session->vnc->disconnect();
+    if (session->web)  session->web->disconnect();
+    if (session->http) session->http->disconnect();
     close(fd);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,10 +48,12 @@ int main(int argc, char* argv[]) {
 
         // ── GuacWebSocketGateway ─────────────────────────────────────────────
         proxy::GuacWebSocketGateway gateway;
+        gateway.set_web_renderer(config.get_web_renderer());
         gateway.start(config.get_guac_port());
         g_gateway = &gateway;
         Logger::info("Guacamole WebSocket gateway listening on port "
-                     + std::to_string(config.get_guac_port()));
+                     + std::to_string(config.get_guac_port())
+                     + " (web_renderer=" + config.get_web_renderer() + ")");
 
         // ── TunnelServer ─────────────────────────────────────────────────────
         proxy::TunnelServer tunnel_server(config.get_agent_port(),

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -29,8 +29,9 @@ Config Config::load_from_file(const std::string& path) {
     config.agent_id_    = j.value("agent_id",    std::string("agent-1"));
 
     // 공통
-    config.verbose_  = j.value("verbose",  false);
-    config.log_file_ = j.value("log_file", std::string(""));
+    config.verbose_      = j.value("verbose",      false);
+    config.log_file_     = j.value("log_file",     std::string(""));
+    config.web_renderer_ = j.value("web_renderer", std::string("http"));
 
     return config;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ add_executable(test_phase8
     ../src/guac_ssh.cpp
     ../src/guac_vnc.cpp
     ../src/guac_web.cpp
+    ../src/guac_http.cpp
     ../src/guac_websocket.cpp
     ../src/utils/logger.cpp
 )
@@ -135,6 +136,7 @@ target_link_libraries(test_phase8
     ZLIB::ZLIB
     OpenSSL::SSL
     OpenSSL::Crypto
+    CURL::libcurl
     pthread
     nlohmann_json::nlohmann_json
 )
@@ -163,6 +165,7 @@ gtest_discover_tests(test_phase11 PROPERTIES LABELS "phase11")
 add_executable(test_phase13
     phase13/test_guac_web.cpp
     ../src/guac_web.cpp
+    ../src/guac_http.cpp
     ../src/guac_websocket.cpp
     ../src/guac_parser.cpp
     ../src/guac_rdp.cpp
@@ -190,6 +193,7 @@ target_link_libraries(test_phase13
     ZLIB::ZLIB
     OpenSSL::SSL
     OpenSSL::Crypto
+    CURL::libcurl
     pthread
     nlohmann_json::nlohmann_json
 )


### PR DESCRIPTION
## 작업 배경

Phase 13(Chromium CDP)은 완성됐지만 두 가지 문제가 남아있었다:

1. **Chromium 방식의 오버헤드**: 단순 HTTP 페이지 조회에 브라우저 프로세스를 fork하는 것은 과도하다. 내부망 관리 페이지, API 엔드포인트, 정적 HTML 접근에는 libcurl 직접 요청이 훨씬 경량하다.
2. **설계 갭**: 지금까지 `web` 구현은 Chromium 하나뿐이었다. JS 실행이 필요 없는 케이스를 위한 경량 구현체가 없었다.

Phase 14-A는 `GuacHttpClient`(libcurl)를 기본 `web` 구현으로 추가하고, `config.json`의 `web_renderer` 필드로 `"http"` / `"chromium"` 중 선택할 수 있게 한다.

## 핵심 개념

- **GuacHttpClient**: libcurl로 URL을 GET하고 응답을 `response` Guacamole instruction으로 반환. `GuacWebClient`(Chromium)와 동일한 `InstructionCallback` 인터페이스를 공유해 `GuacWebSocketGateway`에서 투명하게 교체 가능.
- **response instruction**: `response,<status_code>,<content_type>,<base64_body>;` — 새 커스텀 Guacamole instruction. 브라우저 측에서 수신해 iframe/렌더링에 사용 (Phase 14-C에서 프론트엔드 처리 구현).
- **web_renderer config**: `"http"` (기본) → GuacHttpClient, `"chromium"` → GuacWebClient(기존). `GuacWebSocketGateway::set_web_renderer()`로 start() 전에 설정.

## 변경 사항

- `include/core/guac_http.h` — GuacHttpClient 인터페이스
- `src/guac_http.cpp` — libcurl GET + base64 인코딩(OpenSSL EVP_EncodeBlock) + response instruction 생성
- `include/utils/config.h` — `get_web_renderer()` 추가 (기본값 `"http"`)
- `src/utils/config.cpp` — `web_renderer` JSON 파싱
- `include/core/guac_websocket.h` — `guac_http.h` include + `set_web_renderer()` + `web_renderer_` 멤버
- `src/guac_websocket.cpp` — `web` 프로토콜 라우팅: `web_renderer_=="chromium"`이면 GuacWebClient, 아니면 GuacHttpClient
- `src/main.cpp` — `config.get_web_renderer()`를 `gateway.set_web_renderer()`로 전달
- `CMakeLists.txt`, `tests/CMakeLists.txt` — `find_package(CURL REQUIRED)` + `CURL::libcurl` 링크
- `.github/workflows/ci.yml` — `libcurl4-openssl-dev` 의존성 추가
- `config.json` — `"web_renderer": "http"` 추가
- `CLAUDE.md` — Phase 13 완료 표시, Phase 14 로드맵 추가
- `README.md` — `web` 프로토콜 섹션을 HTTP-first 방식으로 업데이트, `web_renderer` config 문서화

## 핵심 구현 결정

| 코드 / 선택 | 이유 | 다른 방법을 안 쓴 이유 |
|-------------|------|------------------------|
| libcurl `CURLOPT_SSL_VERIFYPEER=0` | 내부망 자체 서명 인증서 허용 | 폐쇄망 환경에서 CA 체인 검증은 실용적이지 않음. 외부 공개 서비스 접근은 GuacWebClient(Chromium)로 처리 |
| `EVP_EncodeBlock` base64 | OpenSSL은 이미 링크된 의존성 — 추가 라이브러리 없음 | libcurl에도 base64가 있으나 공개 API가 아님 |
| `GuacWebClient` 인터페이스 유지 | `GuacWebSocketGateway`의 라우팅 로직이 단순해짐 | 별도 인터페이스를 만들면 `WsSession`에 분기가 늘어남 |
| `set_web_renderer()` (start() 전 호출) | start() 시그니처를 변경하지 않아 하위 호환 유지 | 생성자 인자로 넘기면 테스트 코드에서 Config 없이 `GuacWebSocketGateway` 생성이 불편해짐 |

## 빌드 및 테스트 결과

```
[100%] Built target proxy
[100%] Built target agent
[100%] Built target test_phase8
[100%] Built target test_phase13

CI: passed (23784067229)
```

## 이 작업으로 가능해진 것 / 다음 단계

- `web_renderer=http` (기본): Chromium 없이 내부망 HTTP/HTTPS 페이지 조회 가능
- `web_renderer=chromium`: 기존 CDP 스트리밍 방식 유지
- 다음 세션(14-B): GuacWebSocketGateway ↔ TunnelServer 연결 — NAT 뒤 내부 웹 서비스에 터널 경유 접근

🤖 Generated with [Claude Code](https://claude.com/claude-code)